### PR TITLE
Add overview of possible auth errors

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,6 +1,6 @@
 # Errors
 
-This page contains an overview of all possible errors inside the `https://api.publiq.be/probs/auth/` namespace that can be returned by publiq's APIs. (Not errors that can occur on Auth0 while trying to request a token!)
+This page contains an overview of all possible error types inside the `https://api.publiq.be/probs/auth/` namespace that can be returned by publiq's APIs. (Not errors that can occur on Auth0 while trying to request a token!)
 
 ## unauthorized
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -10,11 +10,11 @@ Your request is missing the required credentials to authenticate.
 
 Possible causes:
 
-- You forgot to include your client id (for endpoints that require client identification)
-- You forgot to include a token (for endpoints that require tokens)
-- Your token has expired
-- Your token is malformed and cannot be parsed
-- You are using the wrong authentication method (client id while it should be a token or the other way around)
+*   You forgot to include your client id (for endpoints that require client identification)
+*   You forgot to include a token (for endpoints that require tokens)
+*   Your token has expired
+*   Your token is malformed and cannot be parsed
+*   You are using the wrong authentication method (client id while it should be a token or the other way around)
 
 ## forbidden
 
@@ -24,6 +24,5 @@ Your request was successfully authenticated but you do not have permission to pe
 
 Possible causes:
 
-- Your client has no access to this API, or your token does not include the correct token to access this API. See [scopes](./scopes.md) for more info.
-- You are trying to perform an action on a specific resource inside the API to which you don't have access. Check the specific API endpoint's documentation for more info about possibly required permissions.
-
+*   Your client has no access to this API, or your token does not include the correct token to access this API. See [scopes](./scopes.md) for more info.
+*   You are trying to perform an action on a specific resource inside the API to which you don't have access. Check the specific API endpoint's documentation for more info about possibly required permissions.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -4,7 +4,9 @@ This page contains an overview of all possible error types inside the `https://a
 
 ## unauthorized
 
-`https://api.publiq.be/probs/auth/unauthorized`
+-   **Complete type:** `https://api.publiq.be/probs/auth/unauthorized`
+-   **Title**: `Unauthorized`
+-   **Status**: `401`
 
 Your request is missing the required credentials to authenticate.
 
@@ -18,7 +20,9 @@ Possible causes:
 
 ## forbidden
 
-`https://api.publiq.be/probs/auth/forbidden`
+-   **Complete type:** `https://api.publiq.be/probs/auth/forbidden`
+-   **Title**: `Forbidden`
+-   **Status**: `403`
 
 Your request was successfully authenticated but you do not have permission to perform this particular request.
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,29 @@
+# Errors
+
+This page contains an overview of all possible errors inside the `https://api.publiq.be/probs/auth/` namespace that can be returned by publiq's APIs. (Not errors that can occur on Auth0 while trying to request a token!)
+
+## unauthorized
+
+`https://api.publiq.be/probs/auth/unauthorized`
+
+Your request is missing the required credentials to authenticate.
+
+Possible causes:
+
+- You forgot to include your client id (for endpoints that require client identification)
+- You forgot to include a token (for endpoints that require tokens)
+- Your token has expired
+- Your token is malformed and cannot be parsed
+- You are using the wrong authentication method (client id while it should be a token or the other way around)
+
+## forbidden
+
+`https://api.publiq.be/probs/auth/forbidden`
+
+Your request was successfully authenticated but you do not have permission to perform this particular request.
+
+Possible causes:
+
+- Your client has no access to this API, or your token does not include the correct token to access this API. See [scopes](./scopes.md) for more info.
+- You are trying to perform an action on a specific resource inside the API to which you don't have access. Check the specific API endpoint's documentation for more info about possibly required permissions.
+

--- a/toc.json
+++ b/toc.json
@@ -35,6 +35,11 @@
     },
     {
       "type": "item",
+      "title": "Errors",
+      "uri": "docs/errors.md"
+    },
+    {
+      "type": "item",
       "title": "CORS",
       "uri": "docs/cors.md"
     }

--- a/toc.json
+++ b/toc.json
@@ -25,13 +25,13 @@
       "uri": "docs/user-access-token.md"
     },
     {
+      "type": "divider",
+      "title": "Other"
+    },
+    {
       "type": "item",
       "title": "Scopes",
       "uri": "docs/scopes.md"
-    },
-    {
-      "type": "divider",
-      "title": "Other"
     },
     {
       "type": "item",


### PR DESCRIPTION
### Added

- Added overview page of possible auth errors

### Changed

- Moved scopes to "Other" category in sidebar, because it's not an "Authentication method"

---

Can be previewed on https://publiq.stoplight.io/docs/authentication/branches/docs%2Ferrors/docs/errors.md (login required)

