### PR TITLE
Token expiration leeway

### DIFF
--- a/docs/client-access-token.md
+++ b/docs/client-access-token.md
@@ -84,6 +84,8 @@ Authorization: Bearer YOUR_ACCESS_TOKEN
 
 > ##### Parsing tokens
 > Do not rely on being able to parse a token as a JWT, for example to check its expiration time. While publiq's access tokens are JWTs right now, this is not guaranteed to always be the case and it might happen that you get a token that is not a parseable JWT at some point in the future.
+>
+> Claims inside the token are also not guaranteed to be stable and may change over time.
 
 <!-- theme: info -->
 

--- a/docs/client-access-token.md
+++ b/docs/client-access-token.md
@@ -85,9 +85,7 @@ Authorization: Bearer YOUR_ACCESS_TOKEN
 
 > ##### Parsing tokens
 >
-> Do not rely on being able to parse a token as a JWT, for example to check its expiration time. While publiq's access tokens are JWTs right now, this is not guaranteed to always be the case and it might happen that you get a token that is not a parseable JWT at some point in the future.
->
-> Claims inside the token are also not guaranteed to be stable and may change over time.
+> **Never** parse a client access token as a JWT, for example to check its expiration time. It is not guaranteed that a client access token will always be a JWT. The claims inside the token can also change, so you should not rely on them.
 
 <!-- theme: info -->
 

--- a/docs/client-access-token.md
+++ b/docs/client-access-token.md
@@ -80,6 +80,11 @@ Authorization: Bearer YOUR_ACCESS_TOKEN
 > 1. Cache the `expires_in` property included in the token response, and the time that you requested the token. Using these two parameters, you can calculate the expiration time of the token and request a new one when it is expired. Note that if you follow this approach, you should account for clock skew between your server and the APIs' servers, so it's best to already request a new token a couple of minutes before the cached one will expire.
 > 2. Keep using the same cached token until you get a `401` response from an API endpoint, at which point you can request a new token and perform the failed request again with the new token. Note that you will need to set a maximum number of retries if you follow this approach, to prevent an infinite loop if there happens to be an issue that prevents you from getting a valid token.
 
+<!-- theme: warning -->
+
+> ##### Parsing tokens
+> Do not rely on being able to parse a token as a JWT, for example to check its expiration time. While publiq's access tokens are JWTs right now, this is not guaranteed to always be the case and it might happen that you get a token that is not a parseable JWT at some point in the future.
+
 <!-- theme: info -->
 
 > ##### Auth0

--- a/docs/client-access-token.md
+++ b/docs/client-access-token.md
@@ -77,12 +77,14 @@ Authorization: Bearer YOUR_ACCESS_TOKEN
 > Make sure to **cache and reuse** the obtained client access token for as long as possible. Do not request a new access token for each API request you make.
 >
 > There are two ways to check if your cached token is still valid:
-> 1. Cache the `expires_in` property included in the token response, and the time that you requested the token. Using these two parameters, you can calculate the expiration time of the token and request a new one when it is expired. Note that if you follow this approach, you should account for clock skew between your server and the APIs' servers, so it's best to already request a new token a couple of minutes before the cached one will expire.
-> 2. Keep using the same cached token until you get a `401` response from an API endpoint, at which point you can request a new token and perform the failed request again with the new token. Note that you will need to set a maximum number of retries if you follow this approach, to prevent an infinite loop if there happens to be an issue that prevents you from getting a valid token.
+>
+> 1.  Cache the `expires_in` property included in the token response, and the time that you requested the token. Using these two parameters, you can calculate the expiration time of the token and request a new one when it is expired. Note that if you follow this approach, you should account for clock skew between your server and the APIs' servers, so it's best to already request a new token a couple of minutes before the cached one will expire.
+> 2.  Keep using the same cached token until you get a `401` response from an API endpoint, at which point you can request a new token and perform the failed request again with the new token. Note that you will need to set a maximum number of retries if you follow this approach, to prevent an infinite loop if there happens to be an issue that prevents you from getting a valid token.
 
 <!-- theme: warning -->
 
 > ##### Parsing tokens
+>
 > Do not rely on being able to parse a token as a JWT, for example to check its expiration time. While publiq's access tokens are JWTs right now, this is not guaranteed to always be the case and it might happen that you get a token that is not a parseable JWT at some point in the future.
 >
 > Claims inside the token are also not guaranteed to be stable and may change over time.

--- a/docs/client-access-token.md
+++ b/docs/client-access-token.md
@@ -76,7 +76,9 @@ Authorization: Bearer YOUR_ACCESS_TOKEN
 >
 > Make sure to **cache and reuse** the obtained client access token for as long as possible. Do not request a new access token for each API request you make.
 >
-> The response with your access token will include an `expires_in` parameter with the exact expiration time in seconds. You can make your cached token expire after that time has elapsed and request a new one then. Another option is to not look at the expiration time and request a new token as soon as you get a `401` response from an API, indicating that the token has expired.
+> There are two ways to check if your cached token is still valid:
+> 1. Cache the `expires_in` property included in the token response, and the time that you requested the token. Using these two parameters, you can calculate the expiration time of the token and request a new one when it is expired. Note that if you follow this approach, you should account for clock skew between your server and the APIs' servers, so it's best to already request a new token a couple of minutes before the cached one will expire.
+> 2. Keep using the same cached token until you get a `401` response from an API endpoint, at which point you can request a new token and perform the failed request again with the new token. Note that you will need to set a maximum number of retries if you follow this approach, to prevent an infinite loop if there happens to be an issue that prevents you from getting a valid token.
 
 <!-- theme: info -->
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -6,9 +6,9 @@ This page contains an overview of all possible error types inside the `https://a
 
 ## unauthorized
 
--   **Complete type:** `https://api.publiq.be/probs/auth/unauthorized`
--   **Title**: `Unauthorized`
--   **Status**: `401`
+*   **Complete type:** `https://api.publiq.be/probs/auth/unauthorized`
+*   **Title**: `Unauthorized`
+*   **Status**: `401`
 
 Your request is missing the required credentials to authenticate.
 
@@ -22,9 +22,9 @@ Possible causes:
 
 ## forbidden
 
--   **Complete type:** `https://api.publiq.be/probs/auth/forbidden`
--   **Title**: `Forbidden`
--   **Status**: `403`
+*   **Complete type:** `https://api.publiq.be/probs/auth/forbidden`
+*   **Title**: `Forbidden`
+*   **Status**: `403`
 
 Your request was successfully authenticated but you do not have permission to perform this particular request.
 

--- a/docs/user-access-token.md
+++ b/docs/user-access-token.md
@@ -80,3 +80,14 @@ Your client id and secret will also vary per environment.
 ## Audience
 
 Both authorization flows require an `audience` parameter when redirecting the user to the authorization server to log in. In both scenarios the audience must be set to  `https://api.publiq.be`.
+
+## Expiration
+
+After you have received your user access token through one of the two OAuth flows described above, there are two ways to check when your token expires:
+
+1. Cache the `expires_in` property included in the token response, and the time that you requested the token. Using these two parameters, you can calculate the expiration time of the token and request a new one when it is expired. Note that if you follow this approach, you should account for clock skew between your server and the APIs' servers, so it's best to already request a new token a couple of minutes before the cached one will expire.
+2. Keep using the same cached token until you get a `401` response from an API endpoint, at which point you can request a new token and perform the failed request again with the new token.
+
+<!-- theme: warning -->
+
+> Avoid parsing the token as a JWT to check its expiration time. While publiq's access tokens are JWTs right now, this is not guaranteed to always be the case and it might happen that you get a token that is not a parseable JWT at some point in the future.

--- a/docs/user-access-token.md
+++ b/docs/user-access-token.md
@@ -90,6 +90,6 @@ After you have received your user access token through one of the two OAuth flow
 
 ## Token parsing
 
-Avoid parsing the token as a JWT, for example to check its expiration time. While publiq's access tokens are JWTs right now, this is not guaranteed to always be the case and it might happen that you get a token that is not a parseable JWT at some point in the future.
+<!-- theme: warning -->
 
-Claims inside the token are also not guaranteed to be stable and may change over time.
+> **Never** parse a user access token as a JWT, for example to check its expiration time. It is not guaranteed that a user access token will always be a JWT. The claims inside the token can also change, so you should not rely on them.

--- a/docs/user-access-token.md
+++ b/docs/user-access-token.md
@@ -88,6 +88,8 @@ After you have received your user access token through one of the two OAuth flow
 1. Cache the `expires_in` property included in the token response, and the time that you requested the token. Using these two parameters, you can calculate the expiration time of the token and request a new one when it is expired. Note that if you follow this approach, you should account for clock skew between your server and the APIs' servers, so it's best to already request a new token a couple of minutes before the cached one will expire.
 2. Keep using the same cached token until you get a `401` response from an API endpoint, at which point you can request a new token and perform the failed request again with the new token.
 
-<!-- theme: warning -->
+## Token parsing
 
-> Avoid parsing the token as a JWT to check its expiration time. While publiq's access tokens are JWTs right now, this is not guaranteed to always be the case and it might happen that you get a token that is not a parseable JWT at some point in the future.
+Avoid parsing the token as a JWT, for example to check its expiration time. While publiq's access tokens are JWTs right now, this is not guaranteed to always be the case and it might happen that you get a token that is not a parseable JWT at some point in the future.
+
+Claims inside the token are also not guaranteed to be stable and may change over time.

--- a/docs/user-access-token.md
+++ b/docs/user-access-token.md
@@ -85,8 +85,8 @@ Both authorization flows require an `audience` parameter when redirecting the us
 
 After you have received your user access token through one of the two OAuth flows described above, there are two ways to check when your token expires:
 
-1. Cache the `expires_in` property included in the token response, and the time that you requested the token. Using these two parameters, you can calculate the expiration time of the token and request a new one when it is expired. Note that if you follow this approach, you should account for clock skew between your server and the APIs' servers, so it's best to already request a new token a couple of minutes before the cached one will expire.
-2. Keep using the same cached token until you get a `401` response from an API endpoint, at which point you can request a new token and perform the failed request again with the new token.
+1.  Cache the `expires_in` property included in the token response, and the time that you requested the token. Using these two parameters, you can calculate the expiration time of the token and request a new one when it is expired. Note that if you follow this approach, you should account for clock skew between your server and the APIs' servers, so it's best to already request a new token a couple of minutes before the cached one will expire.
+2.  Keep using the same cached token until you get a `401` response from an API endpoint, at which point you can request a new token and perform the failed request again with the new token.
 
 ## Token parsing
 


### PR DESCRIPTION
### Added

- Expiration time for user access tokens
- Clock skew info for expiration time of client access tokens
- Warnings not to parse the tokens

---

I thought of documenting this because we just configured a leeway in UDB3 for the `nbf` and `exp` of 30 seconds to account for clock skew (so we accept tokens that have an `nbf` that is max 30 seconds in the future, and an `exp` that is max 30 seconds in the past).

See also https://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#rfc.section.4.1.4

> Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew.

The reason we added this is that we've noticed in the past that some Auth0 tokens were "not valid yet" according to their `nbf`, because there was a clock skew of a couple of seconds between the Auth0 signing servers and our own servers.