### PR TITLE
Document that publiq APIs generally allow CORS requests from any origin

### DIFF
--- a/docs/cors.md
+++ b/docs/cors.md
@@ -1,5 +1,15 @@
 # CORS
 
+<!-- theme: success -->
+
+> Our APIs generally allow CORS requests from **any origin**.
+
+If you encounter CORS issues after all, double check what headers you are trying to include in your requests. Some APIs may only allow headers that they actually use like `authorization` for tokens, `content-type` and `accept` for content negotiation, etc. Try to keep the headers in your request to the ones that are actually required / useful.
+
+If this doesn't solve the issue contact our support for more help. The API you are using might need to be updated to allow requests from any origin, or there might be a bug in the CORS logic on that specific API. Remember to include a copy of the complete request you are trying to send (for example as `HAR` or `curl`), and ideally also include the complete `OPTIONS` request if the browser is doing a preflight request.
+
+## What is CORS?
+
 [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) makes it possible to send HTTP requests that would otherwise be disallowed by a browser's [Same Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy).
 
 For example when you make a request from a **frontend** application to an external API endpoint, you might see the following error in your browser's console:
@@ -9,7 +19,5 @@ For example when you make a request from a **frontend** application to an extern
 This policy is built into modern browsers to for example prevent [CSRF](https://owasp.org/www-community/attacks/csrf) attacks due to the browser making an authenticated request to another domain using cookies, without the consent or the knowledge of the user.
 
 Additionally the Same Origin Policy prevents attacks at websites hosted on an intranet by limiting the requests that a website can make to another website through a browser.
-
-## CORS on publiq's APIs
 
 Because publiq's APIs do not work with cookies and are publicly hosted, there is no need for a strict Same Origin Policy in our case. Therefore our APIs generally allow CORS requests from any origin (unless noted otherwise).

--- a/docs/cors.md
+++ b/docs/cors.md
@@ -6,17 +6,10 @@ For example when you make a request from a **frontend** application to an extern
 
     Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at ...
 
-This policy is built into modern browsers to for example prevent [CSRF](https://owasp.org/www-community/attacks/csrf) attacks.
+This policy is built into modern browsers to for example prevent [CSRF](https://owasp.org/www-community/attacks/csrf) attacks due to the browser making an authenticated request to another domain using cookies, without the consent or the knowledge of the user.
 
-## Circumventing Same Origin Policy & CORS
+Additionally the Same Origin Policy prevents attacks at websites hosted on an intranet by limiting the requests that a website can make to another website through a browser.
 
-In some cases you can circumvent the Same Origin Policy, and thus the need for CORS, by only sending [simple requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests).
+## CORS on publiq's APIs
 
-This is possible on publiq's API endpoints that require no authentication at all or only [client identification](./client-identification.md).
-
-*   When you send a request to an endpoint that requires no authentication, make sure **not to send an `Authorization` header** with a token even if you have one.
-*   When you send a request to an endpoint that requires client identification, you can make your request a "simple" request by **using the `clientId` query parameter** instead of the `x-client-id` header (because simple requests can only contain very specific headers).
-
-## Whitelisting your domain
-
-If you need to send requests to API endpoints from a frontend application and cannot use simple requests, we are happy to add your domain name(s) to our list of allowed CORS domains. Contact vragen@uitdatabank.be for more information.
+Because publiq's APIs do not work with cookies and are publicly hosted, there is no need for a strict Same Origin Policy in our case. Therefore our APIs generally allow CORS requests from any origin (unless noted otherwise).


### PR DESCRIPTION
### Changed

- Updated the CORS page to document that publiq APIs generally allow CORS requests from any origin
